### PR TITLE
More tolerant of whitespace

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -52,8 +52,8 @@ endif
 
 $(OUT_DIR)/Makefile:
 	cd $(OUT_DIR) && \
-		CC=$(CC) \
-		AR=$(AR) \
+		CC="$(CC)" \
+		AR="$(AR)" \
 		FREETYPE_CFLAGS="$(FREETYPE_CFLAGS)" \
 		FREETYPE_LIBS="$(FREETYPE_LIBS)" \
 		CFLAGS="-fPIC" \


### PR DESCRIPTION
ccache users might set their compiler to "ccache gcc", which was
confusing the heck out of the build process