### PR TITLE
Fix missing configuration flags when cross compiling to ARM.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 
 fn main() {
     assert!(Command::new("make")
-        .args(&["-f", "makefile.cargo"])
+        .args(&["-R", "-f", "makefile.cargo"])
         .status()
         .unwrap()
         .success());

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -21,7 +21,11 @@ else
 CC ?= gcc
 AR ?= ar
 
-CONFIGURE_FLAGS := \
+endif
+
+ifneq (android,$(findstring android,$(TARGET)))
+
+CONFIGURE_FLAGS += \
     --sysconfdir=/etc \
     --localstatedir=/var \
     $(NULL)
@@ -38,7 +42,7 @@ $(OUT_DIR)/libfontconfig.a: $(OUT_DIR)/Makefile
 	cd $(OUT_DIR) && make -j4
 	cp $(OUT_DIR)/src/.libs/libfontconfig.a $(OUT_DIR)
 
-ifeq (androideabi,$(findstring androideabi,$(TARGET)))
+ifeq (eabi,$(findstring eabi,$(TARGET)))
 
 EXPAT_FLAGS = --with-expat-includes="$(DEP_EXPAT_OUTDIR)/include" \
               --with-expat-lib="$(DEP_EXPAT_OUTDIR)"


### PR DESCRIPTION
Part of servo/servo#6327

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/11)
<!-- Reviewable:end -->
