### PR TITLE
Link to upstream Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ build = "build.rs"
 name = "fontconfig_sys"
 path = "lib.rs"
 
-[dependencies.expat-sys]
-git = "https://github.com/servo/libexpat"
-
-[dependencies.freetype-sys]
-git = "https://github.com/servo/libfreetype2"
-
+[dependencies]
+expat-sys = { git = "https://github.com/servo/libexpat" }
+freetype-sys = { git = "https://github.com/servo/libfreetype2" }

--- a/lib.rs
+++ b/lib.rs
@@ -1,1 +1,2 @@
-// Intentionally blank
+extern crate expat_sys;
+extern crate freetype_sys;


### PR DESCRIPTION
This ensures that the compiler will order libraries on the command line
correctly and also bring in all the libs