### PR TITLE
win32 build fixes; find fontconfig via pkg-config if it's an appropriate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ path = "lib.rs"
 [dependencies]
 expat-sys = { git = "https://github.com/servo/libexpat" }
 freetype-sys = { git = "https://github.com/servo/libfreetype2" }
+
+[build-dependencies]
+pkg-config = "0.3"
+

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate pkg_config;
+
 use std::process::Command;
 use std::env;
 
-
 fn main() {
+    // if the system version of fontconfig is at least 2.11.1, use it
+    if pkg_config::Config::new().atleast_version("2.11.1").find("fontconfig").is_ok() {
+        return;
+    }
+
     assert!(Command::new("make")
         .args(&["-R", "-f", "makefile.cargo"])
         .status()


### PR DESCRIPTION
This uses pkg-config to see if the system already has fontconfig built, and if so just uses it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/17)
<!-- Reviewable:end -->
