### PR TITLE
Only set target-specific CC and AR for cross-compile

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,4 +1,4 @@
-ifeq (eabi,$(findstring eabi,$(TARGET)))
+ifneq ($(HOST),$(TARGET))
 
 CC ?= $(TARGET)-gcc
 AR ?= $(TARGET)-ar
@@ -42,7 +42,7 @@ $(OUT_DIR)/libfontconfig.a: $(OUT_DIR)/Makefile
 	cd $(OUT_DIR) && make -j$(NUM_JOBS)
 	cp $(OUT_DIR)/src/.libs/libfontconfig.a $(OUT_DIR)
 
-ifeq (eabi,$(findstring eabi,$(TARGET)))
+ifneq ($(HOST),$(TARGET))
 
 EXPAT_FLAGS = --with-expat-includes="$(DEP_EXPAT_OUTDIR)/include" \
               --with-expat-lib="$(DEP_EXPAT_OUTDIR)"


### PR DESCRIPTION
Checking for "eabi" in $TARGET causes failure to build natively on ARM systems.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/18)
<!-- Reviewable:end -->
