### PR TITLE
Properly locate the freetype2 header files when built from sources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -56,7 +56,7 @@ ifneq ($(HOST),$(TARGET))
 
 EXPAT_FLAGS = --with-expat-includes="$(DEP_EXPAT_OUTDIR)/include" \
               --with-expat-lib="$(DEP_EXPAT_OUTDIR)"
-FREETYPE_CFLAGS = -I$(DEP_FREETYPE_OUTDIR)/include
+FREETYPE_CFLAGS = -I$(DEP_FREETYPE_OUTDIR)/include/freetype2
 FREETYPE_LIBS = -L$(DEP_FREETYPE_OUTDIR) -lfreetype
 
 else


### PR DESCRIPTION
r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/24)
<!-- Reviewable:end -->
