### PR TITLE
Fix android link error

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -55,9 +55,9 @@ $(OUT_DIR)/libfontconfig.a: $(OUT_DIR)/Makefile
 ifneq ($(HOST),$(TARGET))
 
 EXPAT_FLAGS = --with-expat-includes="$(DEP_EXPAT_OUTDIR)/include" \
-              --with-expat-lib="$(DEP_EXPAT_OUTDIR)"
+              --with-expat-lib="$(DEP_EXPAT_OUTDIR)/lib"
 FREETYPE_CFLAGS = -I$(DEP_FREETYPE_OUTDIR)/include/freetype2
-FREETYPE_LIBS = -L$(DEP_FREETYPE_OUTDIR) -lfreetype
+FREETYPE_LIBS = -L$(DEP_FREETYPE_OUTDIR)/lib -lfreetype
 
 else
 


### PR DESCRIPTION
The current code failing with the following error when i run `cargo build --target=arm-linux-androideabi`:

`--- stderr
configure: WARNING: using cross tools not prefixed with host triplet
configure: error: 
*** expat is required. or try to use --enable-libxml2
make: *** [libfontconfig/target/arm-linux-androideabi/debug/build/servo-fontconfig-sys-eb36aa9f180e86ea/out/Makefile] Error 1
thread 'main' panicked at 'assertion failed: Command::new("make").args(&["-R", "-f",
                            "makefile.cargo"]).status().unwrap().success()', build.rs:17
`

With the proposed changes it works fine on `android` and `linux`. (i can't test other platforms)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/25)
<!-- Reviewable:end -->
