### PR TITLE
Allow setting external compiler flags

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -30,6 +30,7 @@ endif
 
 # On MSVC, no -FPIC
 ifeq (,$(findstring windows-msvc,$(TARGET)))
+CFLAGS += -fPIC
 CXXFLAGS += -fPIC
 endif
 
@@ -73,7 +74,7 @@ $(OUT_DIR)/Makefile:
 		AR="$(AR)" \
 		FREETYPE_CFLAGS="$(FREETYPE_CFLAGS)" \
 		FREETYPE_LIBS="$(FREETYPE_LIBS)" \
-		CFLAGS="-fPIC" \
+		CFLAGS="$(CFLAGS)" \
 		$(SRC_DIR)/configure \
 		--disable-docs \
 		--disable-shared \


### PR DESCRIPTION
`libfontconfig` ignores custom CFLAGS during the build, which can cause problems eg. during cross compilation.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/26)
<!-- Reviewable:end -->
