### PR TITLE
Fix Android sysroot path

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -10,7 +10,6 @@ CONFIGURE_FLAGS := \
 
     CONFIGURE_FLAGS += \
         --with-default-fonts=/system/fonts \
-        --with-sysroot=$(ANDROID_TOOLCHAIN)/sysroot \
         --with-cache-dir=/sdcard/servo/.fccache \
         $(NULL)
 


### PR DESCRIPTION
This will fix the Android sysroot path, after https://github.com/servo/servo/issues/13154#issuecomment-250632827 lands.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/27)
<!-- Reviewable:end -->
