### PR TITLE
Pass the --target flag to C when building for Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "4.0.4"
+version = "4.0.5"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"

--- a/configure
+++ b/configure
@@ -1894,9 +1894,14 @@ case "(($ac_try" in
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
 $as_echo "$ac_try_echo"; } >&5
+  echo "cflags: $CFLAGS"
+  echo "cppflags: $CPPFLAGS"
+  echo "ldflags: $LDFLAGS"
+  echo "libs: $LIBS"
   (eval "$ac_link") 2>conftest.err
   ac_status=$?
   if test -s conftest.err; then
+    cat conftest.err
     grep -v '^ *+' conftest.err >conftest.er1
     cat conftest.er1 >&5
     mv -f conftest.er1 conftest.err
@@ -14091,7 +14096,7 @@ if test "$os_win32" = "no"; then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for scandir" >&5
 $as_echo_n "checking for scandir... " >&6; }
 	fc_saved_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS $WARN_CFLAGS -Werror"
+	CFLAGS="$CFLAGS $WARN_CFLAGS"
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -9,7 +9,7 @@ ifeq (armv7-linux-androideabi,$(TARGET))
 	# Reset TARGET variable because armv7 target name used by Rust is not 
 	# the same as the target name needed for the CXX toolchain.
 	TARGET = arm-linux-androideabi
-	FLAGS += -march=armv7-a -mfpu=neon
+	FLAGS += -march=armv7-a -mfpu=neon --target=$(TARGET)
 endif
 
 ifneq ($(HOST),$(TARGET))


### PR DESCRIPTION
Allows building for Android with clang. Part of https://github.com/servo/servo/pull/21029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/35)
<!-- Reviewable:end -->
