### PR TITLE
Use environment variables for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "4.0.5"
+version = "4.0.6"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -61,12 +61,15 @@ $(OUT_DIR)/libfontconfig.a: $(OUT_DIR)/Makefile
 	cd $(OUT_DIR) && make -j$(NUM_JOBS)
 	cp $(OUT_DIR)/src/.libs/libfontconfig.a $(OUT_DIR)
 
+EXPAT_INCLUDE_DIR ?= $(DEP_EXPAT_OUTDIR)/include
+EXPAT_LIB_DIR ?= $(DEP_EXPAT_OUTDIR)/lib
+
 ifneq ($(HOST),$(TARGET))
 
-EXPAT_FLAGS = --with-expat-includes="$(DEP_EXPAT_OUTDIR)/include" \
-              --with-expat-lib="$(DEP_EXPAT_OUTDIR)/lib"
-FREETYPE_CFLAGS = -I$(DEP_FREETYPE_OUTDIR)/include/freetype2
-FREETYPE_LIBS = -L$(DEP_FREETYPE_OUTDIR)/lib -lfreetype
+EXPAT_FLAGS = --with-expat-includes="$(EXPAT_INCLUDE_DIR)" \
+              --with-expat-lib="$(EXPAT_LIB_DIR)"
+FREETYPE_CFLAGS ?= -I$(DEP_FREETYPE_OUTDIR)/include/freetype2
+FREETYPE_LIBS ?= -L$(DEP_FREETYPE_OUTDIR)/lib -lfreetype
 
 else
 


### PR DESCRIPTION
Allow `$EXPAT_INCLUDE_DIR` and `$EXPAT_LIB_DIR` to be configured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/36)
<!-- Reviewable:end -->
