### PR TITLE
Do not use pkg-config on Android

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,10 +8,13 @@ use std::process::Command;
 use std::env;
 
 fn main() {
-    // if the system version of fontconfig is at least 2.11.1, use it
-    if let Ok(lib) = pkg_config::Config::new().atleast_version("2.11.1").find("fontconfig") {
-        println!("cargo:incdir={}", lib.include_paths[0].clone().into_os_string().into_string().unwrap());
-        return;
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("android") {
+        // If the system version of fontconfig isgat least 2.11.1, use it.
+        if let Ok(lib) = pkg_config::Config::new().atleast_version("2.11.1").find("fontconfig") {
+            println!("cargo:incdir={}", lib.include_paths[0].clone().into_os_string().into_string().unwrap());
+            return;
+        }
     }
 
     assert!(Command::new("make")


### PR DESCRIPTION
Similar to https://github.com/servo/libexpat/pull/22 This is currently working because Servo is not setting PKG_CONFIG_ALLOW_CROSS, but we need to set it now to build servo-media.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfontconfig/37)
<!-- Reviewable:end -->
