### PR TITLE
Fix intermittent build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "4.0.7"
+version = "4.0.8"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -90,7 +90,8 @@ $(OUT_DIR)/Makefile:
 		--disable-docs \
 		--disable-shared \
 		$(EXPAT_FLAGS) \
-		$(strip $(CONFIGURE_FLAGS))
+		$(strip $(CONFIGURE_FLAGS)) &&
+		touch $(SRC_DIR)/src/fcobjshash.h
 
 else
 


### PR DESCRIPTION
This is a symptom of a change in Cargo (https://github.com/rust-lang/cargo/pull/7465) that no longer preserves the mtime of files extracted during the package download process. This means that generated files included in this repository can end up being regenerated unnecessarily unless we explicitly force them to be treated as more recent than their source files.