### PR TITLE
Fix makefile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "4.0.8"
+version = "4.0.9"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -90,7 +90,7 @@ $(OUT_DIR)/Makefile:
 		--disable-docs \
 		--disable-shared \
 		$(EXPAT_FLAGS) \
-		$(strip $(CONFIGURE_FLAGS)) &&
+		$(strip $(CONFIGURE_FLAGS)) && \
 		touch $(SRC_DIR)/src/fcobjshash.h
 
 else


### PR DESCRIPTION
Fixes #43 

Turns out the makefile was missing a backslash to escape a newline.

This bumps the version, so a `cargo publish` is needed. And probably a `cargo yank` of the previous version since it doesn't build.