### PR TITLE
Replace servo-freetype-sys depedency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 expat-sys = "2.1.0"
-servo-freetype-sys = "4.0.0"
+freetype-sys = "0.9.0"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 expat-sys = "2.1.0"
-freetype-sys = "0.9.0"
+freetype-sys = "0.10.0"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
This replaces the servo-freetype-sys depedency with freetype-sys from
the piston project.

The goal is to standardize on a singular system library, to make sure no
conflicts come up when trying to combine piston's and servo's freetype
and fontconfig libraries.

While it would be possible to instead deprecate freetype-sys in favor of
servo-freetype-sys, I think it makes sense to standardize on the library
that has the most generic name and is easy to search for.

I've looked at the other libraries that depend on servo-freetype-sys
like servo's freetype and have also tried updating servo-freetype and
managed to successfully build Alacritty against it. As far as I can tell
updating should not be a problem and I'll send more PRs immediately if
this suggestion should be accepted.