### PR TITLE
Bump freetype-sys to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 expat-sys = "2.1.0"
-freetype-sys = "0.10.0"
+freetype-sys = "0.11.0"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
This fixes a build error when trying to build freetype2 manually.