### PR TITLE
Bump version to 5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"


### PR DESCRIPTION
Since #49 updated the freetype-sys version to 0.11.0, this should allow
consumers to make use of the new version without having to manually
update anything themselves.

Since 0.11.0 was just a fix for an existing build failure when building
freetype from source, it should not require a breaking version change.