### PR TITLE
Bump version to 5.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "5.0.1"
+version = "5.0.2"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"


### PR DESCRIPTION
This should solve issues of using libfontconfig and freetype-sys in the same
project, without manually patching them.

Since freetype-sys 0.12.0 was just an addition of new FFI
bindings, it should not require a breaking change.