### PR TITLE
 Bump version to 5.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fontconfig-sys"
-version = "5.0.2"
+version = "5.1.0"
 authors = ["Keith Packard <keithp@keithp.com>", "Patrick Lam <plam@mit.edu>"]
 license = "MIT"
 description = "Font configuration and customization library"


### PR DESCRIPTION
 This should solve issues of using libfontconfig and freetype-sys in the same
 project, without manually patching them.

 Since freetype-sys 0.13.0 was just an addition of new FFI
 bindings, it should not require a breaking change.

 The minor version was bumped due to introducing new feature
 `force_system_lib`.