### PR TITLE
Build for musl target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ path = "lib.rs"
 expat-sys = "2.1.0"
 freetype-sys = "0.13.0"
 
+[package.metadata.system-deps]
+fontconfig = "2.11"
+
 [build-dependencies]
-pkg-config = "0.3"
+system-deps = "3.1.2"
 
 [features]
 default = []


### PR DESCRIPTION
This PR refactors the `build.rs` script to allow the `musl` target builds.

The used command is: 
```
env CXX=g++ PKG_CONFIG_ALLOW_CROSS=1 cargo build --target x86_64-unknown-linux-musl
```

Thanks in advance for your review! :)