### PR TITLE
Bump freetype-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 expat-sys = "2.1.0"
-freetype-sys = "0.13.0"
+freetype-sys = "0.15.0"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
This brings freetype-sys up to date so servo-fontconfig can be used
together with the latest version of freetype-rs.