### PR TITLE
Bump freetype-sys verion to 0.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  RUSTFLAGS: -Cdebuginfo=0
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+        toolchain: [stable, 1.60.0]
+    steps:
+      - uses: actions/checkout@v2
+
+      # install the toolchain we are going to compile and test with
+      - name: install ${{ matrix.toolchain }} toolchain
+        id: install_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+
+      # we want to install the latest nightly with clippy and rustfmt to run checks against stable
+      - name: install nightly toolchain
+        id: install_nightly_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          components: clippy, rustfmt
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+
+      # run rustfmt and clippy checks, but only once
+      - run: cargo +nightly fmt --all -- --check
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+
+      #- run: cargo +nightly clippy -Z unstable-options --workspace --all-targets --all-features
+      #  if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+
+      # run tests
+      - run: cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: rust
-sudo: false
-branches:
-  except:
-    - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 expat-sys = "2.1.0"
-freetype-sys = "0.13.0"
+freetype-sys = "0.17.0"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn main() {
 
     assert!(Command::new("make")
         .env("MAKEFLAGS", env::var("CARGO_MAKEFLAGS").unwrap_or_default())
-        .args(&["-R", "-f", "makefile.cargo"])
+        .args(["-R", "-f", "makefile.cargo"])
         .status()
         .unwrap()
         .success());


### PR DESCRIPTION
Similar to #66  but with never version 0.17

@jdm  i know that  #68 is the problem for CI to work

travis is doing only `cargo test --verbose` see https://docs.travis-ci.com/user/languages/rust/#default-build-script

doing this manually results in 
```rust
 cargo test --verbose                                                                                                                                                                                                      SIGINT(2) ↵  104625  23:01:52 
       Fresh cc v1.0.78
       Fresh pkg-config v0.3.26
       Fresh cmake v0.1.49
   Compiling libc v0.2.138
   Compiling expat-sys v2.1.6
     Running `rustc --crate-name libc /home/marcel/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.138/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=69616d19e7f5808b -C extra-filename=-69616d19e7f5808b --out-dir /mnt/games/cargo-build/debug/deps -L dependency=/mnt/games/cargo-build/debug/deps --cap-lints allow --cfg freebsd11 --cfg libc_priv_mod_use --cfg libc_union --cfg libc_const_size_of --cfg libc_align --cfg libc_int128 --cfg libc_core_cvoid --cfg libc_packedN --cfg libc_cfg_target_vendor --cfg libc_non_exhaustive --cfg libc_ptr_addr_of --cfg libc_underscore_const_names --cfg libc_const_extern_fn`
     Running `rustc --crate-name expat_sys /home/marcel/.cargo/registry/src/github.com-1ecc6299db9ec823/expat-sys-2.1.6/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=83682155b781efdb -C extra-filename=-83682155b781efdb --out-dir /mnt/games/cargo-build/debug/deps -L dependency=/mnt/games/cargo-build/debug/deps --cap-lints allow -L native=/usr/lib -l expat`
   Compiling freetype-sys v0.17.0
     Running `rustc --crate-name freetype_sys /home/marcel/.cargo/registry/src/github.com-1ecc6299db9ec823/freetype-sys-0.17.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=785e83877b338b41 -C extra-filename=-785e83877b338b41 --out-dir /mnt/games/cargo-build/debug/deps -L dependency=/mnt/games/cargo-build/debug/deps --extern libc=/mnt/games/cargo-build/debug/deps/liblibc-69616d19e7f5808b.rmeta --cap-lints allow -L native=/mnt/games/cargo-build/debug/build/freetype-sys-3eeefe42bd09af1a/out -l static=freetype2 -l stdc++`
   Compiling servo-fontconfig-sys v5.1.0 (/mnt/games/entw/libfontconfig)
     Running `rustc --crate-name fontconfig_sys lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' -C metadata=d8b59f1c357e5e46 -C extra-filename=-d8b59f1c357e5e46 --out-dir /mnt/games/cargo-build/debug/deps -C incremental=/mnt/games/cargo-build/debug/incremental -L dependency=/mnt/games/cargo-build/debug/deps --extern expat_sys=/mnt/games/cargo-build/debug/deps/libexpat_sys-83682155b781efdb.rmeta --extern freetype_sys=/mnt/games/cargo-build/debug/deps/libfreetype_sys-785e83877b338b41.rmeta -L native=/usr/lib -l fontconfig -l freetype -L native=/usr/lib -L native=/mnt/games/cargo-build/debug/build/freetype-sys-3eeefe42bd09af1a/out`
     Running `rustc --crate-name fontconfig_sys lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' -C metadata=33ac12cf06e997d2 -C extra-filename=-33ac12cf06e997d2 --out-dir /mnt/games/cargo-build/debug/deps -C incremental=/mnt/games/cargo-build/debug/incremental -L dependency=/mnt/games/cargo-build/debug/deps --extern expat_sys=/mnt/games/cargo-build/debug/deps/libexpat_sys-83682155b781efdb.rlib --extern freetype_sys=/mnt/games/cargo-build/debug/deps/libfreetype_sys-785e83877b338b41.rlib -L native=/usr/lib -l fontconfig -l freetype -L native=/usr/lib -L native=/mnt/games/cargo-build/debug/build/freetype-sys-3eeefe42bd09af1a/out`
    Finished test [unoptimized + debuginfo] target(s) in 1.29s
     Running `/mnt/games/cargo-build/debug/deps/fontconfig_sys-33ac12cf06e997d2`

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests fontconfig_sys
     Running `rustdoc --crate-type lib --crate-name fontconfig_sys --test /mnt/games/entw/libfontconfig/lib.rs -L dependency=/mnt/games/cargo-build/debug/deps -L dependency=/mnt/games/cargo-build/debug/deps -L native=/mnt/games/cargo-build/debug/build/freetype-sys-3eeefe42bd09af1a/out -L native=/usr/lib --extern expat_sys=/mnt/games/cargo-build/debug/deps/libexpat_sys-83682155b781efdb.rlib --extern freetype_sys=/mnt/games/cargo-build/debug/deps/libfreetype_sys-785e83877b338b41.rlib --extern fontconfig_sys=/mnt/games/cargo-build/debug/deps/libfontconfig_sys-d8b59f1c357e5e46.rlib -C embed-bitcode=no --cfg 'feature="default"' --error-format human`

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Though to be on the save side i also included a basic github actions scripts. But i think to enable it the repo owner needs to go to the settings and switch from travis to github actions somewhere. I travis is only doing a basic check i just added a check for a constant rust toolchain and stable on ubuntu, have cargo check and cargo test